### PR TITLE
Added support for Expect-CT header

### DIFF
--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/ExpectCtConfiguration.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/ExpectCtConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NWebsec.AspNetCore.Core.HttpHeaders.Configuration
+{
+    public class ExpectCtConfiguration : IExpectCtConfiguration
+    {
+        public TimeSpan MaxAge { get; set; }
+        public bool Enforce { get; set; }
+        public string ReportUri { get; set; }
+    }
+}

--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/IExpectCtConfiguration.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/IExpectCtConfiguration.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace NWebsec.AspNetCore.Core.HttpHeaders.Configuration
+{
+    public interface IExpectCtConfiguration
+    {
+        TimeSpan MaxAge { get; set; }
+        bool Enforce { get; set; }
+        string ReportUri { get; set; }
+    }
+}

--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/Validation/HpkpConfigurationValidator.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/Validation/HpkpConfigurationValidator.cs
@@ -37,19 +37,5 @@ namespace NWebsec.AspNetCore.Core.HttpHeaders.Configuration.Validation
 
             throw new Exception("Malformed thumbprint, expected 20 HEX octets without any leading or trailing whitespace, was: " + thumbPrint);
         }
-
-        public void ValidateReportUri(string reportUri)
-        {
-            Uri result;
-            if (!Uri.TryCreate(reportUri, UriKind.Absolute, out result))
-            {
-                throw new Exception("Report URIs must be absolute URIs. This is not: " + reportUri);
-            }
-            
-            if (!ValidSchemes.Any(s => s.Equals(result.Scheme)))
-            {
-                throw new Exception("Report URIs must have the http or https scheme. Got: " + reportUri);
-            }
-        }
     }
 }

--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/Validation/ReportUriValidator.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/Configuration/Validation/ReportUriValidator.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+
+namespace NWebsec.AspNetCore.Core.HttpHeaders.Configuration.Validation
+{
+    public class ReportUriValidator
+    {
+        private static readonly string[] ValidSchemes = { "http", "https" };
+
+        public void ValidateReportUri(string reportUri)
+        {
+            Uri result;
+            if (!Uri.TryCreate(reportUri, UriKind.Absolute, out result))
+            {
+                throw new Exception("Report URIs must be absolute URIs. This is not: " + reportUri);
+            }
+
+            if (!ValidSchemes.Any(s => s.Equals(result.Scheme)))
+            {
+                throw new Exception("Report URIs must have the http or https scheme. Got: " + reportUri);
+            }
+        }
+    }
+}

--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/HeaderConstants.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/HeaderConstants.cs
@@ -15,6 +15,7 @@ namespace NWebsec.AspNetCore.Core.HttpHeaders
         public static readonly string HpkpHeader = "Public-Key-Pins";
         public static readonly string HpkpReportOnlyHeader = "Public-Key-Pins-Report-Only";
         public static readonly string ReferrerPolicyHeader = "Referrer-Policy";
+        public static readonly string ExpectCtHeader = "Expect-CT";
 
         public static readonly string[] CspSourceList =
         {

--- a/src/NWebsec.AspNetCore.Core/HttpHeaders/HeaderGenerator.cs
+++ b/src/NWebsec.AspNetCore.Core/HttpHeaders/HeaderGenerator.cs
@@ -62,6 +62,32 @@ namespace NWebsec.AspNetCore.Core.HttpHeaders
         }
 
         [CanBeNull]
+        public HeaderResult CreateExpectCtResult(IExpectCtConfiguration expectCtConfig)
+        {
+            if (expectCtConfig.MaxAge < TimeSpan.Zero) return null;
+            
+            var seconds = (int)expectCtConfig.MaxAge.TotalSeconds;
+
+            var sb = new StringBuilder();
+            if(expectCtConfig.Enforce)
+            {
+                sb.Append("enforce; ");
+            }
+
+            sb.Append($"max-age={seconds}");
+
+            if(!string.IsNullOrWhiteSpace(expectCtConfig.ReportUri))
+            {
+                sb.Append($"; report-uri=\"{expectCtConfig.ReportUri}\"");
+            }
+
+            var value = sb.ToString();
+
+            return new HeaderResult(HeaderResult.ResponseAction.Set, HeaderConstants.ExpectCtHeader,
+                value);
+        }
+
+        [CanBeNull]
         public HeaderResult CreateXContentTypeOptionsResult(ISimpleBooleanConfiguration xContentTypeOptionsConfig,
             ISimpleBooleanConfiguration oldXContentTypeOptionsConfig = null)
         {

--- a/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
@@ -221,5 +221,21 @@ namespace Microsoft.AspNetCore.Builder
             configurer(options);
             return app.UseMiddleware<CspMiddleware>(options, true); //Last param indicates it's reportOnly.
         }
+
+        /// <summary>
+        ///     Adds a middleware to the ASP.NET Core pipeline that sets the Expect-CT header.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder" /> to which the middleware is added.</param>
+        /// <param name="configurer">An <see cref="Action" /> that configures the options for the middleware.</param>
+        /// <returns>The <see cref="IApplicationBuilder" /> supplied in the app parameter.</returns>
+        public static IApplicationBuilder UseExpectCt(this IApplicationBuilder app, Action<IFluentExpectCtOptions> configurer)
+        {
+            if (app == null) throw new ArgumentNullException(nameof(app));
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            var options = new ExpectCtOptions();
+            configurer(options);
+            return app.UseMiddleware<ExpectCtMiddleware>(options);
+        }
     }
 }

--- a/src/NWebsec.AspNetCore.Middleware/ExpectCtOptions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/ExpectCtOptions.cs
@@ -1,0 +1,47 @@
+﻿using NWebsec.AspNetCore.Core.HttpHeaders.Configuration.Validation;
+using System;
+
+namespace NWebsec.AspNetCore.Middleware
+{
+    public class ExpectCtOptions :ExpectCtOptionsConfiguration, IFluentExpectCtOptions
+    {
+        private readonly ReportUriValidator _validator;
+
+        public ExpectCtOptions()
+        {
+            _validator = new ReportUriValidator();
+        }
+
+        public new IFluentExpectCtOptions MaxAge(int days = 0, int hours = 0, int minutes = 0, int seconds = 0)
+        {
+            if (days < 0) throw new ArgumentOutOfRangeException(nameof(days), "Value must be equal to or larger than 0.");
+            if (hours < 0) throw new ArgumentOutOfRangeException(nameof(hours), "Value must be equal to or larger than 0.");
+            if (minutes < 0) throw new ArgumentOutOfRangeException(nameof(minutes), "Value must be equal to or larger than 0.");
+            if (seconds < 0) throw new ArgumentOutOfRangeException(nameof(seconds), "Value must be equal to or larger than 0.");
+
+            base.MaxAge = new TimeSpan(days, hours, minutes, seconds);
+            return this;
+        }
+
+        public new IFluentExpectCtOptions Enforce()
+        {
+            base.Enforce = true;
+            return this;
+        }
+
+        public new IFluentExpectCtOptions ReportUri(string reportUri)
+        {
+            try
+            {
+                _validator.ValidateReportUri(reportUri);
+            }
+            catch (Exception e)
+            {
+                throw new ArgumentException(e.Message, nameof(reportUri));
+            }
+
+            base.ReportUri = reportUri;
+            return this;
+        }
+    }
+}

--- a/src/NWebsec.AspNetCore.Middleware/ExpectCtOptionsConfiguration.cs
+++ b/src/NWebsec.AspNetCore.Middleware/ExpectCtOptionsConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using NWebsec.AspNetCore.Core.HttpHeaders.Configuration;
+using System;
+using System.ComponentModel;
+
+namespace NWebsec.AspNetCore.Middleware
+{
+    public class ExpectCtOptionsConfiguration : IExpectCtConfiguration
+    {
+        internal ExpectCtOptionsConfiguration()
+        {
+            MaxAge = TimeSpan.Zero;
+            Enforce = false;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public TimeSpan MaxAge { get; set; }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Enforce { get; set; }
+
+        public string ReportUri { get; set; }
+    }
+}

--- a/src/NWebsec.AspNetCore.Middleware/HpkpOptions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/HpkpOptions.cs
@@ -12,6 +12,7 @@ namespace NWebsec.AspNetCore.Middleware
     {
         private readonly List<string> _pins;
         private readonly HpkpConfigurationValidator _validator;
+        private readonly ReportUriValidator _reportUriValidator;
 
         internal HpkpOptionsConfiguration Config { get; set; }
 
@@ -20,6 +21,7 @@ namespace NWebsec.AspNetCore.Middleware
             _pins = new List<string>();
             Config = new HpkpOptionsConfiguration { Pins = _pins };
             _validator = new HpkpConfigurationValidator();
+            _reportUriValidator = new ReportUriValidator();
         }
 
         // ReSharper disable once CSharpWarnings::CS0109
@@ -44,7 +46,7 @@ namespace NWebsec.AspNetCore.Middleware
         {
             try
             {
-                _validator.ValidateReportUri(reportUri);
+                _reportUriValidator.ValidateReportUri(reportUri);
             }
             catch (Exception e)
             {

--- a/src/NWebsec.AspNetCore.Middleware/IFluentExpectCtOptions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/IFluentExpectCtOptions.cs
@@ -1,0 +1,31 @@
+﻿using NWebsec.AspNetCore.Core.Fluent;
+using System;
+
+namespace NWebsec.AspNetCore.Middleware
+{
+    public interface IFluentExpectCtOptions : IFluentInterface
+    {
+        /// <summary>
+        /// Specifies the max age for the ExpectCT header.
+        /// </summary>
+        /// <param name="days">The number of days added to max age.</param>
+        /// <param name="hours">The number of hours added to max age.</param>
+        /// <param name="minutes">The number of minutes added to max age.</param>
+        /// <param name="seconds">The number of seconds added to max age.</param>
+        /// <returns>The current instance.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if a negative value was supplied in any of the parameters.</exception>
+        IFluentExpectCtOptions MaxAge(int days = 0, int hours = 0, int minutes = 0, int seconds = 0);
+
+        /// <summary>
+        /// Specifies a report URI where the browser can send ExpectCT reports.
+        /// </summary>
+        /// <param name="reportUri">The report URI, which is an absolute URI with scheme http or https.</param>
+        /// <returns>The current instance.</returns>
+        IFluentExpectCtOptions ReportUri(string reportUri);
+
+        /// <summary>
+        /// Specifies if the browser should enforce ExpectCT or just report on it.
+        /// </summary>
+        IFluentExpectCtOptions Enforce();
+    }
+}

--- a/src/NWebsec.AspNetCore.Middleware/Middleware/ExpectCtMiddleware.cs
+++ b/src/NWebsec.AspNetCore.Middleware/Middleware/ExpectCtMiddleware.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.AspNetCore.Http;
+using NWebsec.AspNetCore.Core.HttpHeaders;
+using NWebsec.AspNetCore.Core.HttpHeaders.Configuration;
+
+namespace NWebsec.AspNetCore.Middleware.Middleware
+{
+    public class ExpectCtMiddleware : MiddlewareBase
+    {
+        private readonly IExpectCtConfiguration _config;
+        private readonly HeaderResult _headerResult;
+
+        public ExpectCtMiddleware(RequestDelegate next, ExpectCtOptions options) : base(next)
+        {
+            _config = options;
+
+            var headerGenerator = new HeaderGenerator();
+            _headerResult = headerGenerator.CreateExpectCtResult(_config);
+        }
+
+        internal override void PreInvokeNext(HttpContext context)
+        {
+            if(_headerResult.Action == HeaderResult.ResponseAction.Set)
+            {
+                context.Response.Headers[_headerResult.Name] = _headerResult.Value;
+            }
+        }
+    }
+}

--- a/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/Configuration/Validation/HpkpConfigurationValidatorTests.cs
+++ b/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/Configuration/Validation/HpkpConfigurationValidatorTests.cs
@@ -111,24 +111,5 @@ namespace NWebsec.AspNetCore.Core.Tests.HttpHeaders.Configuration.Validation
         {
             Assert.Throws<Exception>(() => _validator.ValidateThumbprint("a0 a1 ab 90 c9 fc 84 7b 3b 12 61 e8 97 7d 5f d3 22 61 d3  cc"));
         }
-
-        [Fact]
-        public void ValidateReportUri_AbsoluteUriWithValidScheme_NoException()
-        {
-            _validator.ValidateReportUri("http://nwebsec.com/report");
-            _validator.ValidateReportUri("https://nwebsec.com/report");
-        }
-
-        [Fact]
-        public void ValidateReportUri_RelativeUri_ThrowsException()
-        {
-            Assert.Throws<Exception>(() => _validator.ValidateReportUri("/report"));
-        }
-
-        [Fact]
-        public void ValidateReportUri_WrongScheme_ThrowsException()
-        {
-            Assert.Throws<Exception>(() => _validator.ValidateReportUri("ftp://nwebsec.com/report"));
-        }
     }
 }

--- a/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/Configuration/Validation/ReportUriValidatorTests.cs
+++ b/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/Configuration/Validation/ReportUriValidatorTests.cs
@@ -1,0 +1,35 @@
+﻿using NWebsec.AspNetCore.Core.HttpHeaders.Configuration.Validation;
+using System;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Core.Tests.HttpHeaders.Configuration.Validation
+{
+    public class ReportUriValidatorTests
+    {
+        private readonly ReportUriValidator _validator;
+
+        public ReportUriValidatorTests()
+        {
+            _validator = new ReportUriValidator();
+        }
+
+        [Fact]
+        public void ValidateReportUri_AbsoluteUriWithValidScheme_NoException()
+        {
+            _validator.ValidateReportUri("http://nwebsec.com/report");
+            _validator.ValidateReportUri("https://nwebsec.com/report");
+        }
+
+        [Fact]
+        public void ValidateReportUri_RelativeUri_ThrowsException()
+        {
+            Assert.Throws<Exception>(() => _validator.ValidateReportUri("/report"));
+        }
+
+        [Fact]
+        public void ValidateReportUri_WrongScheme_ThrowsException()
+        {
+            Assert.Throws<Exception>(() => _validator.ValidateReportUri("ftp://nwebsec.com/report"));
+        }
+    }
+}

--- a/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/HeaderGeneratorTests.ExpectCt.cs
+++ b/test/NWebsec.AspNetCore.Core.Tests/HttpHeaders/HeaderGeneratorTests.ExpectCt.cs
@@ -1,0 +1,85 @@
+﻿using NWebsec.AspNetCore.Core.HttpHeaders;
+using NWebsec.AspNetCore.Core.HttpHeaders.Configuration;
+using System;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Core.Tests.HttpHeaders
+{
+    public partial class HeaderGeneratorTests
+    {
+        [Fact]
+        public void CreateExpectCtResult_NegativeTimespanInConfig_ReturnsNull()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(-1) };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+            
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CreateExpectCtResult_ZeroTimespanInConfig_ReturnsSetExpectCtResult()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(0) };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal("Expect-CT", result.Name);
+            Assert.Equal("max-age=0", result.Value);
+        }
+
+        [Fact]
+        public void CreateExpectCtResult_24hInConfig_ReturnsSetExpectCtsResult()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(24, 0, 0) };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal("Expect-CT", result.Name);
+            Assert.Equal("max-age=86400", result.Value);
+        }
+
+        [Fact]
+        public void CreateExpectCtResult_24hInConfigAndEnforce_ReturnsSetExpectCtResult()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(24, 0, 0), Enforce = true };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal("Expect-CT", result.Name);
+            Assert.Equal("enforce; max-age=86400", result.Value);
+        }
+
+        [Fact]
+        public void CreateExpectCtResult_24hInConfigAndEnforceAndReportUri_ReturnsSetExpectCtResult()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(24, 0, 0), Enforce = true, ReportUri = "https://localhost/" };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal("Expect-CT", result.Name);
+            Assert.Equal("enforce; max-age=86400; report-uri=\"https://localhost/\"", result.Value);
+        }
+
+        [Fact]
+        public void CreateExpectCtResult_24hInConfigAndReportUri_ReturnsSetExpectCtResult()
+        {
+            var expectCtConfig = new ExpectCtConfiguration { MaxAge = new TimeSpan(24, 0, 0), ReportUri = "https://localhost/" };
+
+            var result = _generator.CreateExpectCtResult(expectCtConfig);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal("Expect-CT", result.Name);
+            Assert.Equal("max-age=86400; report-uri=\"https://localhost/\"", result.Value);
+        }
+    }
+}

--- a/test/NWebsec.AspNetCore.Core.Tests/NWebsec.AspNetCore.Core.Tests.csproj
+++ b/test/NWebsec.AspNetCore.Core.Tests/NWebsec.AspNetCore.Core.Tests.csproj
@@ -31,4 +31,8 @@
     <Folder Include="Properties\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Include="HttpHeaders\HeaderGeneratorTests.ExpectCt.cs" />
+  </ItemGroup>
+
 </Project>

--- a/test/NWebsec.AspNetCore.Middleware.Tests/ExpectCtOptionsTest.cs
+++ b/test/NWebsec.AspNetCore.Middleware.Tests/ExpectCtOptionsTest.cs
@@ -1,0 +1,49 @@
+﻿using NWebsec.AspNetCore.Core.HttpHeaders.Configuration;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Middleware.Tests
+{
+    public class ExpectCtOptionsTest
+    {
+        private readonly ExpectCtOptions _options;
+
+        public ExpectCtOptionsTest()
+        {
+            _options = new ExpectCtOptions();
+        }
+
+        [Fact]
+        public void Ctor_Enforce_DefaultFalse()
+        {
+            Assert.False(((IExpectCtConfiguration)_options).Enforce);
+        }
+
+        [Fact]
+        public void MaxAge_ValidMaxage_SetsMaxage()
+        {
+            _options.MaxAge(minutes: 30);
+
+            Assert.True(new TimeSpan(0, 30, 0) == ((IExpectCtConfiguration)_options).MaxAge);
+        }
+
+        [Fact]
+        public void MaxAge_ZeroMaxage_SetsMaxage()
+        {
+            _options.MaxAge();
+
+            Assert.True(TimeSpan.Zero == ((IExpectCtConfiguration)_options).MaxAge);
+        }
+
+        [Fact]
+        public void MaxAge_NegativeValues_ThrowsException()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => _options.MaxAge(0, 0, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _options.MaxAge(0, 0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _options.MaxAge(0, -1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => _options.MaxAge(-1));
+        }
+    }
+}

--- a/test/NWebsec.AspNetCore.Middleware.Tests/Middleware/ExpectCtMiddlewareTests.cs
+++ b/test/NWebsec.AspNetCore.Middleware.Tests/Middleware/ExpectCtMiddlewareTests.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Middleware.Tests.Middleware
+{
+    public class ExpectCtMiddlewareTests
+    {
+        [Fact]
+        public async Task ExpectCt_MaxageOnly_AddsHeader()
+        {
+            using (var server = new TestServer(new WebHostBuilder().Configure(app =>
+            {
+                app.UseExpectCt(config => config.MaxAge(1));
+                app.Run(async ctx =>
+                {
+
+                    await ctx.Response.WriteAsync("Hello world using OWIN TestServer");
+                });
+            })))
+            {
+                using (var httpClient = server.CreateClient())
+                {
+                    var response = await httpClient.GetAsync("https://localhost/");
+
+                    Assert.True(response.Headers.Contains("Expect-CT"));
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds support for Expect-CT header.
Fixes #99 

- Refactors ReportURI validation out to a separate class.
- Added config and middleware for Expect-CT
- Added tests for both config and middleware.

Looking at the code base before working on this, it looked like implementations were done in 2 different ways, so I just picked one of the styles for this, but I'm open to changing it if needed.