### PR TITLE
Added support for 'allow-downloads' attribute for CSP sandbox directive

### DIFF
--- a/src/NWebsec.AspNet.Classic/Modules/Configuration/Csp/CspSandboxDirectiveConfigurationElement.cs
+++ b/src/NWebsec.AspNet.Classic/Modules/Configuration/Csp/CspSandboxDirectiveConfigurationElement.cs
@@ -15,6 +15,13 @@ namespace NWebsec.Modules.Configuration.Csp
             set => this["enabled"] = value;
         }
 
+        [ConfigurationProperty("allow-downloads", IsRequired = false, DefaultValue = false)]
+        public bool AllowDownloads
+        {
+            get => (bool)this["allow-downloads"];
+            set => this["allow-downloads"] = value;
+        }
+
         [ConfigurationProperty("allow-forms", IsRequired = false, DefaultValue = false)]
         public bool AllowForms
         {

--- a/src/NWebsec.AspNet.Classic/nupkgcontent/NWebsecConfig/HttpHeaderSecurityModuleConfig.xsd
+++ b/src/NWebsec.AspNet.Classic/nupkgcontent/NWebsecConfig/HttpHeaderSecurityModuleConfig.xsd
@@ -514,6 +514,11 @@
               <xs:documentation>This attribute is required. Specifies whether to include the sandbox CSP directive (CSP 1.0).</xs:documentation>
             </xs:annotation>
           </xs:attribute>
+          <xs:attribute name="allow-downloads" type="simple_boolean" use="optional">
+            <xs:annotation>
+              <xs:documentation>Optional. Specifies whether to include the allow-downloads source. The default is false.</xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
           <xs:attribute name="allow-forms" type="simple_boolean" use="optional">
             <xs:annotation>
               <xs:documentation>Optional. Specifies whether to include the allow-forms source. The default is false.</xs:documentation>

--- a/src/NWebsec.AspNet.Mvc/HttpHeaders/Csp/Internals/CspSandboxAttributeBase.cs
+++ b/src/NWebsec.AspNet.Mvc/HttpHeaders/Csp/Internals/CspSandboxAttributeBase.cs
@@ -35,6 +35,11 @@ namespace NWebsec.Mvc.HttpHeaders.Csp.Internals
         public bool Enabled { get => _directive.Enabled; set => _directive.Enabled = value; }
 
         /// <summary>
+        /// Sets whether the allow-downloads flag is included in the sandbox directive. The default is false.
+        /// </summary>
+        public bool AllowDownloads { get => throw new NotSupportedException(); set => _directive.AllowDownloads = value; }
+
+        /// <summary>
         /// Sets whether the allow-forms flag is included in the sandbox directive. The default is false.
         /// </summary>
         public bool AllowForms { get => throw new NotSupportedException(); set => _directive.AllowForms = value; }

--- a/src/NWebsec.AspNetCore.Mvc/Csp/Internals/CspSandboxAttributeBase.cs
+++ b/src/NWebsec.AspNetCore.Mvc/Csp/Internals/CspSandboxAttributeBase.cs
@@ -35,6 +35,11 @@ namespace NWebsec.AspNetCore.Mvc.Csp.Internals
         public bool Enabled { get => _directive.Enabled;set => _directive.Enabled = value;}
 
         /// <summary>
+        /// Sets whether the allow-downloads flag is included in the sandbox directive. The default is false.
+        /// </summary>
+        public bool AllowDownloads { get => throw new NotSupportedException(); set => _directive.AllowDownloads = value; }
+
+        /// <summary>
         /// Sets whether the allow-forms flag is included in the sandbox directive. The default is false.
         /// </summary>
         public bool AllowForms { get => throw new NotSupportedException();set => _directive.AllowForms = value;}

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/CspSandboxDirectiveConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/CspSandboxDirectiveConfiguration.cs
@@ -5,6 +5,7 @@ namespace NWebsec.Core.Common.HttpHeaders.Configuration
     public class CspSandboxDirectiveConfiguration : ICspSandboxDirectiveConfiguration
     {
         public bool Enabled { get; set; }
+        public bool AllowDownloads { get; set; }
         public bool AllowForms { get; set; }
         public bool AllowModals { get; set; }
         public bool AllowOrientationLock { get; set; }

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/ICspSandboxDirectiveConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/ICspSandboxDirectiveConfiguration.cs
@@ -16,6 +16,11 @@ namespace NWebsec.Core.Common.HttpHeaders.Configuration
         ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
         ///     made.
         /// </summary>
+        bool AllowDownloads { get; set; }
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
         bool AllowForms { get; set; }
         /// <summary>
         ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been

--- a/src/NWebsec.Core.Shared/HttpHeaders/HeaderGenerator.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/HeaderGenerator.cs
@@ -319,6 +319,11 @@ namespace NWebsec.Core.Common.HttpHeaders
 
             var sources = new List<string>();
 
+            if (directive.AllowDownloads)
+            {
+                sources.Add("allow-downloads");
+            }
+
             if (directive.AllowForms)
             {
                 sources.Add("allow-forms");

--- a/src/NWebsec.Core.Shared/Middleware/Options/FluentCspSandboxDirective.cs
+++ b/src/NWebsec.Core.Shared/Middleware/Options/FluentCspSandboxDirective.cs
@@ -6,6 +6,12 @@ namespace NWebsec.Core.Common.Middleware.Options
 {
     class FluentCspSandboxDirective : CspSandboxDirectiveConfiguration, IFluentCspSandboxDirective
     {
+        public new IFluentCspSandboxDirective AllowDownloads()
+        {
+            base.AllowDownloads = true;
+            return this;
+        }
+
         public new IFluentCspSandboxDirective AllowForms()
         {
             base.AllowForms = true;

--- a/src/NWebsec.Core.Shared/Middleware/Options/IFluentCspSandboxDirective.cs
+++ b/src/NWebsec.Core.Shared/Middleware/Options/IFluentCspSandboxDirective.cs
@@ -7,6 +7,11 @@ namespace NWebsec.Core.Common.Middleware.Options
     public interface IFluentCspSandboxDirective : IFluentInterface
     {
         /// <summary>
+        ///     Sets the 'allow-downloads' source for the CSP sandbox directive.
+        /// </summary>
+        IFluentCspSandboxDirective AllowDownloads();
+
+        /// <summary>
         ///     Sets the 'allow-forms' source for the CSP sandbox directive.
         /// </summary>
         IFluentCspSandboxDirective AllowForms();

--- a/src/NWebsec.Mvc.Common/Csp/CspSandboxOverride.cs
+++ b/src/NWebsec.Mvc.Common/Csp/CspSandboxOverride.cs
@@ -5,6 +5,7 @@ namespace NWebsec.Mvc.Common.Csp
     public class CspSandboxOverride
     {
         public bool Enabled { get; set; }
+        public bool? AllowDownloads { get; set; }
         public bool? AllowForms { get; set; }
         public bool? AllowModals { get; set; }
         public bool? AllowOrientationLock { get; set; }

--- a/src/NWebsec.Mvc.Common/Helpers/CspConfigMapper.cs
+++ b/src/NWebsec.Mvc.Common/Helpers/CspConfigMapper.cs
@@ -124,6 +124,7 @@ namespace NWebsec.Mvc.Common.Helpers
             return new CspSandboxDirectiveConfiguration
             {
                 Enabled = oldDirective.Enabled,
+                AllowDownloads = oldDirective.AllowDownloads,
                 AllowForms = oldDirective.AllowForms,
                 AllowModals = oldDirective.AllowModals,
                 AllowOrientationLock = oldDirective.AllowOrientationLock,

--- a/src/NWebsec.Mvc.Common/Helpers/CspDirectiveOverrideHelper.cs
+++ b/src/NWebsec.Mvc.Common/Helpers/CspDirectiveOverrideHelper.cs
@@ -81,6 +81,11 @@ namespace NWebsec.Mvc.Common.Helpers
 
             result.Enabled = directiveOverride.Enabled;
 
+            if (directiveOverride.AllowDownloads.HasValue)
+            {
+                result.AllowDownloads = (bool)directiveOverride.AllowDownloads;
+            }
+
             if (directiveOverride.AllowForms.HasValue)
             {
                 result.AllowForms = (bool)directiveOverride.AllowForms;

--- a/test/NWebsec.Core.SharedProject.Tests/HttpHeaders/HeaderGeneratorCspTests.cs
+++ b/test/NWebsec.Core.SharedProject.Tests/HttpHeaders/HeaderGeneratorCspTests.cs
@@ -416,6 +416,7 @@ namespace NWebsec.Core.SharedProject.Tests.HttpHeaders
                 Enabled = true,
                 SandboxDirective = {
                     Enabled = true,
+                    AllowDownloads = true,
                     AllowForms = true,
                     AllowModals = true,
                     AllowOrientationLock = true,
@@ -434,7 +435,7 @@ namespace NWebsec.Core.SharedProject.Tests.HttpHeaders
             Assert.NotNull(result);
             Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
             Assert.Equal(CspHeaderName(reportOnly), result.Name);
-            Assert.Equal("sandbox allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation", result.Value);
+            Assert.Equal("sandbox allow-downloads allow-forms allow-modals allow-orientation-lock allow-pointer-lock allow-popups allow-popups-to-escape-sandbox allow-presentation allow-same-origin allow-scripts allow-top-navigation", result.Value);
         }
 
         [Theory]

--- a/test/NWebsec.Core.SharedProject.Tests/Middleware/Options/FluentCspSandboxDirectiveTests.cs
+++ b/test/NWebsec.Core.SharedProject.Tests/Middleware/Options/FluentCspSandboxDirectiveTests.cs
@@ -16,6 +16,14 @@ namespace NWebsec.Core.SharedProject.Tests.Middleware.Options
         }
 
         [Fact]
+        public void AllowDownloads_SetsAllowDownloads()
+        {
+            _options.AllowDownloads();
+
+            Assert.True(((CspSandboxDirectiveConfiguration)_options).AllowDownloads);
+        }
+
+        [Fact]
         public void AllowForms_SetsAllowForms()
         {
             _options.AllowForms();

--- a/test/NWebsec.Mvc.CommonProject.Tests/Helpers/CspConfigMapperTests.cs
+++ b/test/NWebsec.Mvc.CommonProject.Tests/Helpers/CspConfigMapperTests.cs
@@ -187,6 +187,7 @@ namespace NWebsec.Mvc.CommonProject.Tests.Helpers
         {
             var firstDirective = new CspSandboxDirectiveConfiguration
             {
+                AllowDownloads = true,
                 AllowForms = true,
                 AllowModals = true,
                 AllowOrientationLock = true,

--- a/test/NWebsec.Mvc.CommonProject.Tests/Helpers/CspDirectiveOverrideHelperTests.cs
+++ b/test/NWebsec.Mvc.CommonProject.Tests/Helpers/CspDirectiveOverrideHelperTests.cs
@@ -321,6 +321,30 @@ namespace NWebsec.Mvc.CommonProject.Tests.Helpers
 
         [Theory]
         [MemberData(nameof(FalseThenTrue))]
+        public void GetOverridenCspSandboxConfig_AllowDownloadsOverride_OverridesAllowDownloads(bool expectedResult)
+        {
+            var directiveConfig = new CspSandboxDirectiveConfiguration { AllowDownloads = !expectedResult };
+            var directiveOverride = new CspSandboxOverride { AllowDownloads = expectedResult };
+
+            var newConfig = _overrideHelper.GetOverridenCspSandboxConfig(directiveOverride, directiveConfig);
+
+            Assert.Equal(expectedResult, newConfig.AllowDownloads);
+        }
+
+        [Theory]
+        [MemberData(nameof(FalseThenTrue))]
+        public void GetOverridenCspSandboxConfig_AllowDownloadsNotSet_InheritsAllowDownloads(bool expectedResult)
+        {
+            var directiveConfig = new CspSandboxDirectiveConfiguration { AllowDownloads = expectedResult };
+            var directiveOverride = new CspSandboxOverride();
+
+            var newConfig = _overrideHelper.GetOverridenCspSandboxConfig(directiveOverride, directiveConfig);
+
+            Assert.Equal(expectedResult, newConfig.AllowDownloads);
+        }
+
+        [Theory]
+        [MemberData(nameof(FalseThenTrue))]
         public void GetOverridenCspSandboxConfig_AllowFormsOverride_OverridesAllowForms(bool expectedResult)
         {
             var directiveConfig = new CspSandboxDirectiveConfiguration { AllowForms = !expectedResult };

--- a/test/NWebsec.Mvc.CommonProject.Tests/TestHelpers/CspSandboxDirectiveConfigurationEqualityComparer.cs
+++ b/test/NWebsec.Mvc.CommonProject.Tests/TestHelpers/CspSandboxDirectiveConfigurationEqualityComparer.cs
@@ -10,6 +10,7 @@ namespace NWebsec.Mvc.CommonProject.Tests.TestHelpers
         public bool Equals(ICspSandboxDirectiveConfiguration x, ICspSandboxDirectiveConfiguration y)
         {
             return x.Enabled.Equals(y.Enabled) &&
+                x.AllowDownloads.Equals(y.AllowDownloads) &&
                 x.AllowForms.Equals(y.AllowForms) &&
                 x.AllowModals.Equals(y.AllowModals) &&
                 x.AllowOrientationLock.Equals(y.AllowOrientationLock) &&

--- a/test/NWebsec.Mvc.CommonProject.Tests/TestHelpers/CspSandboxDirectiveConfigurationEqualityComparerTests.cs
+++ b/test/NWebsec.Mvc.CommonProject.Tests/TestHelpers/CspSandboxDirectiveConfigurationEqualityComparerTests.cs
@@ -33,6 +33,16 @@ namespace NWebsec.Mvc.CommonProject.Tests.TestHelpers
         }
 
         [Fact]
+        public void Equals_AllowDownloadsDiffers_ReturnsFalse()
+        {
+            var firstConfig = new CspSandboxDirectiveConfiguration { AllowDownloads = false };
+            var secondConfig = new CspSandboxDirectiveConfiguration { AllowDownloads = true };
+
+            Assert.False(_equalityComparer.Equals(firstConfig, secondConfig));
+            Assert.False(_equalityComparer.Equals(secondConfig, firstConfig));
+        }
+
+        [Fact]
         public void Equals_AllowFormsDiffers_ReturnsFalse()
         {
             var firstConfig = new CspSandboxDirectiveConfiguration { AllowForms = false };


### PR DESCRIPTION
As reported in issue #168 Chrome browser no longer allows downloads if Sandbox mode is enabled and allow-downloads is not explicitly specified. This pull request adds support for an 'allow-downloads' attribute on the Sandbox directive.