### PR TITLE
If URL provided as absolute with no scheme specified add request schema

### DIFF
--- a/src/NWebsec.AspNetCore.Core/RedirectValidator.cs
+++ b/src/NWebsec.AspNetCore.Core/RedirectValidator.cs
@@ -29,6 +29,9 @@ namespace NWebsec.AspNetCore.Core
                 return;
             }
 
+            // Cleanup
+            locationHeader = locationHeader.TrimStart();
+
             // If URL starts with two slashes than add request autority scheme
             if (locationHeader.StartsWith("//"))
             {

--- a/src/NWebsec.AspNetCore.Core/RedirectValidator.cs
+++ b/src/NWebsec.AspNetCore.Core/RedirectValidator.cs
@@ -29,6 +29,12 @@ namespace NWebsec.AspNetCore.Core
                 return;
             }
 
+            // If URL starts with two slashes than add request autority scheme
+            if (locationHeader.StartsWith("//"))
+            {
+                locationHeader = requestAuthority.Scheme + ":" + locationHeader;
+            }
+
             Uri locationUri;
             if (!Uri.TryCreate(locationHeader, UriKind.RelativeOrAbsolute, out locationUri))
             {

--- a/test/NWebsec.AspNetCore.Core.Tests/RedirectValidatorTests.cs
+++ b/test/NWebsec.AspNetCore.Core.Tests/RedirectValidatorTests.cs
@@ -50,6 +50,16 @@ namespace NWebsec.AspNetCore.Core.Tests
         }
 
         [Fact]
+        public void ValidateRedirect_EnabledAndRedirectNoSchemeWithSpace_ThrowsException()
+        {
+            const int statusCode = 302;
+            const string location = " //evilsite.com";
+            var config = new RedirectValidationConfiguration { Enabled = true };
+
+            Assert.Throws<RedirectValidationException>(() => _redirectValidator.ValidateRedirect(statusCode, location, RequestUriHttps, config));
+        }
+
+        [Fact]
         public void ValidateRedirect_EnabledAndNoRedirect_NoException()
         {
             var config = new RedirectValidationConfiguration { Enabled = true };

--- a/test/NWebsec.AspNetCore.Core.Tests/RedirectValidatorTests.cs
+++ b/test/NWebsec.AspNetCore.Core.Tests/RedirectValidatorTests.cs
@@ -40,6 +40,16 @@ namespace NWebsec.AspNetCore.Core.Tests
         }
 
         [Fact]
+        public void ValidateRedirect_EnabledAndRedirectNoScheme_ThrowsException()
+        {
+            const int statusCode = 302;
+            const string location = "//evilsite.com";
+            var config = new RedirectValidationConfiguration { Enabled = true };
+
+            Assert.Throws<RedirectValidationException>(() => _redirectValidator.ValidateRedirect(statusCode, location, RequestUriHttps, config));
+        }
+
+        [Fact]
         public void ValidateRedirect_EnabledAndNoRedirect_NoException()
         {
             var config = new RedirectValidationConfiguration { Enabled = true };
@@ -244,7 +254,7 @@ namespace NWebsec.AspNetCore.Core.Tests
 
             Assert.Throws<RedirectValidationException>(() => _redirectValidator.ValidateRedirect(statusCode, "https://www.nwebsec.com/", RequestUriHttp, config));
             Assert.Throws<RedirectValidationException>(() => _redirectValidator.ValidateRedirect(statusCode, "https://www.nwebsec.com:443/", RequestUriHttp, config));
-            
+
         }
 
         [Fact]


### PR DESCRIPTION
Redirects to `//evilsite.com` succeed to redirect to it, improve check to block such url's