### PR TITLE
Add support for Permissions-Policy header in ASP.NET Core

### DIFF
--- a/NWebsec.sln
+++ b/NWebsec.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29613.14
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32319.34
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{1733BF96-BCF6-43DD-B145-EBCB11B57C55}"
 EndProject
@@ -63,8 +63,14 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MvcClassic", "src\MvcClassi
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\NWebsec.Mvc.Common\NWebsec.Mvc.Common.projitems*{10521d31-e95a-447d-9e32-4a02c6689880}*SharedItemsImports = 5
 		src\NWebsec.Core.Shared\NWebsec.Core.Shared.projitems*{22c7c96d-f411-444a-a30e-64cfbda506f5}*SharedItemsImports = 13
 		src\NWebsec.Mvc.Common\NWebsec.Mvc.Common.projitems*{4c0a345e-976a-4f84-a568-50501b1b2dbd}*SharedItemsImports = 13
+		src\NWebsec.Core.Shared\NWebsec.Core.Shared.projitems*{7163b923-8a2e-47ab-a2ee-6abca91c42fa}*SharedItemsImports = 5
+		src\NWebsec.Mvc.Common\NWebsec.Mvc.Common.projitems*{abb44397-b534-4ae4-98e4-4032c05e85c2}*SharedItemsImports = 5
+		src\NWebsec.Core.Shared\NWebsec.Core.Shared.projitems*{ace9f21a-3ff6-4cb0-b264-d2b44bc581fa}*SharedItemsImports = 5
+		src\NWebsec.Core.Shared\NWebsec.Core.Shared.projitems*{eb433b3f-3a17-4216-9032-60904a6f2f2a}*SharedItemsImports = 5
+		src\NWebsec.Mvc.Common\NWebsec.Mvc.Common.projitems*{f9b06c0f-594a-47cd-af83-8d47c5417569}*SharedItemsImports = 5
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
@@ -199,5 +199,15 @@ namespace Microsoft.AspNetCore.Builder
             configurer(options);
             return app.UseMiddleware<CspMiddleware>(options, true); //Last param indicates it's reportOnly.
         }
+
+        public static IApplicationBuilder UsePermissionsPolicy(this IApplicationBuilder app, Action<IFluentPermissionsPolicyOptions> configurer)
+        {
+            if(app == null) throw new ArgumentNullException(nameof(app));
+            if (configurer == null) throw new ArgumentNullException(nameof(configurer));
+
+            var options = new PermissionsPolicyOptions();
+            configurer(options);
+            return app.UseMiddleware<PermissionsPolicyMiddleware>(options);
+        }
     }
 }

--- a/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/ApplicationBuilderExtensions.cs
@@ -200,6 +200,12 @@ namespace Microsoft.AspNetCore.Builder
             return app.UseMiddleware<CspMiddleware>(options, true); //Last param indicates it's reportOnly.
         }
 
+        /// <summary>
+        ///     Adds a middleware to the ASP.NET Core pipeline that sets the Permissions-Policy header.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder" /> to which the middleware is added.</param>
+        /// <param name="configurer">An <see cref="Action" /> that configures the options for the middleware.</param>
+        /// <returns>The <see cref="IApplicationBuilder" /> supplied in the app parameter.</returns>
         public static IApplicationBuilder UsePermissionsPolicy(this IApplicationBuilder app, Action<IFluentPermissionsPolicyOptions> configurer)
         {
             if(app == null) throw new ArgumentNullException(nameof(app));

--- a/src/NWebsec.AspNetCore.Middleware/Middleware/PermissionsPolicyMiddleware.cs
+++ b/src/NWebsec.AspNetCore.Middleware/Middleware/PermissionsPolicyMiddleware.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using Microsoft.AspNetCore.Http;
+using NWebsec.AspNetCore.Core.Extensions;
+using NWebsec.Core.Common.HttpHeaders;
+
+namespace NWebsec.AspNetCore.Middleware.Middleware
+{
+    public class PermissionsPolicyMiddleware : MiddlewareBase
+    {
+        private readonly IPermissionsPolicyConfiguration _config;
+        private readonly HeaderResult _headerResult;
+
+        public PermissionsPolicyMiddleware(RequestDelegate next, IPermissionsPolicyConfiguration config) : base(next)
+        {
+            _config = config;
+
+            var headerGenerator = new HeaderGenerator();
+            _headerResult = headerGenerator.CreatePermissionsPolicyResult(_config);
+        }
+
+        internal override void PreInvokeNext(HttpContext context)
+        {
+            context.GetNWebsecContext().PermissionsPolicy = _config;
+            if (_headerResult.Action == HeaderResult.ResponseAction.Set)
+            {
+                context.Response.Headers[_headerResult.Name] = _headerResult.Value;
+            }
+        }
+    }
+}

--- a/src/NWebsec.AspNetCore.Middleware/PermissionsPolicyPermissionExtensions.cs
+++ b/src/NWebsec.AspNetCore.Middleware/PermissionsPolicyPermissionExtensions.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+using NWebsec.Core.Common.HttpHeaders.PermissionsPolicy;
+
+namespace NWebsec.AspNetCore.Middleware
+{
+    public static class PermissionsPolicyPermissionExtensions
+    {
+        /// <summary>
+        ///     Sets the "all" source for the PermissionsPolicy permission.
+        /// </summary>
+        /// <typeparam name="T">The type of the PermissionsPolicy permission configuration object.</typeparam>
+        /// <param name="permission">The PermissionsPolicy permission configuration object.</param>
+        /// <exception cref="InvalidOperationException">Thrown when sources have already been configured for the permission.</exception>
+        public static void All<T>(this T permission) where T : class, IPermissionsPolicyPermissionConfiguration
+        {
+            if (permission == null) throw new ArgumentNullException(nameof(permission));
+
+            permission.AllSrc = true;
+        }
+
+        /// <summary>
+        ///     Sets the "none" source for the PermissionsPolicy permission. This source cannot be combined with other sources on a PermissionsPolicy permission.
+        /// </summary>
+        /// <typeparam name="T">The type of the PermissionsPolicy permission configuration object.</typeparam>
+        /// <param name="permission">The PermissionsPolicy permission configuration object.</param>
+        /// <exception cref="InvalidOperationException">Thrown when sources have already been configured for the permission.</exception>
+        public static void None<T>(this T permission) where T : class, IPermissionsPolicyPermissionConfiguration
+        {
+            if (permission == null) throw new ArgumentNullException(nameof(permission));
+
+            ValidateBeforeSettingNoneSource(permission);
+            permission.NoneSrc = true;
+        }
+
+        /// <summary>
+        ///     Sets the "self" source for the PermissionsPolicy permission.
+        /// </summary>
+        /// <typeparam name="T">The type of the PermissionsPolicy permission configuration object.</typeparam>
+        /// <param name="permission">The PermissionsPolicy permission configuration object.</param>
+        /// <returns>The PermissionsPolicy permission configuration object.</returns>
+        public static T Self<T>(this T permission) where T : class, IPermissionsPolicyPermissionConfiguration
+        {
+            if (permission == null) throw new ArgumentNullException(nameof(permission));
+
+            permission.SelfSrc = true;
+            return permission;
+        }
+
+        /// <summary>
+        ///     Sets custom sources for the PermissionsPolicy permission.
+        /// </summary>
+        /// <typeparam name="T">The type of the PermissionsPolicy permission configuration object.</typeparam>
+        /// <param name="permission">The PermissionsPolicy permission configuration object.</param>
+        /// <param name="sources">One or more custom sources.</param>
+        /// <returns>The PermissionsPolicy permission configuration object.</returns>
+        public static T CustomSources<T>(this T permission, params string[] sources) where T : class, IPermissionsPolicyPermissionConfiguration
+        {
+            if (permission == null) throw new ArgumentNullException(nameof(permission));
+            if (sources.Length == 0) throw new ArgumentException("You must supply at least one source.", nameof(sources));
+
+            try
+            {
+                var type = typeof(T);
+                permission.CustomSources = sources
+                    .Select(s => PermissionsPolicyUriSource.Parse(s).ToString())
+                    .ToArray();
+            }
+            catch (InvalidPermissionsPolicySourceException e)
+            {
+                throw new ArgumentException("Invalid source. Details: " + e.Message, nameof(sources), e);
+            }
+
+            return permission;
+        }
+
+        private static void ValidateBeforeSettingNoneSource(IPermissionsPolicyPermissionConfiguration permission)
+        {
+            if (permission.AllSrc || permission.SelfSrc || (permission.CustomSources != null && permission.CustomSources.Any()))
+            {
+                throw new InvalidOperationException("It is a logical error to combine the \"None\" source with other sources.");
+            }
+        }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/IPermissionsPolicyConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/IPermissionsPolicyConfiguration.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace NWebsec.Core.Common.HttpHeaders.Configuration
+{
+    /// <summary>
+    ///     Defines the properties required for CSP directive configuration.
+    /// </summary>
+    public interface IPermissionsPolicyPermissionConfiguration
+    {
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool Enabled { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool All { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool None { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool Self { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<string> CustomSources { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/IPermissionsPolicyPermissionConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/IPermissionsPolicyPermissionConfiguration.cs
@@ -1,0 +1,48 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace NWebsec.Core.Common.HttpHeaders.Configuration
+{
+    /// <summary>
+    ///     Defines the properties required for CSP directive configuration.
+    /// </summary>
+    public interface IPermissionsPolicyPermissionConfiguration
+    {
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool Enabled { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool AllSrc { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool NoneSrc { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        bool SelfSrc { get; set; }
+
+        /// <summary>
+        ///     Infrastructure. Not intended to be used by your code directly. An attempt to hide this from Intellisense has been
+        ///     made.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        IEnumerable<string> CustomSources { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/PermissionsPolicyPermissionConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/PermissionsPolicyPermissionConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NWebsec.Core.Common.HttpHeaders.Configuration
+{
+    public class PermissionsPolicyPermissionPermissionConfiguration : IPermissionsPolicyPermissionConfiguration
+    {
+        private static readonly string[] EmptySources = new string[0];
+
+        public PermissionsPolicyPermissionPermissionConfiguration()
+        {
+            Enabled = true;
+            CustomSources = EmptySources;
+        }
+
+        public bool Enabled { get; set; }
+        public bool All { get; set; }
+        public bool None { get; set; }
+        public bool Self { get; set; }
+        public IEnumerable<string> CustomSources { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/Configuration/PermissionsPolicyPermissionPermissionConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/Configuration/PermissionsPolicyPermissionPermissionConfiguration.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace NWebsec.Core.Common.HttpHeaders.Configuration
+{
+    public class PermissionsPolicyPermissionConfiguration : IPermissionsPolicyPermissionConfiguration
+    {
+        private static readonly string[] EmptySources = new string[0];
+
+        public PermissionsPolicyPermissionConfiguration()
+        {
+            Enabled = true;
+            CustomSources = EmptySources;
+        }
+
+        public bool Enabled { get; set; }
+        public bool AllSrc { get; set; }
+        public bool NoneSrc { get; set; }
+        public bool SelfSrc { get; set; }
+        public IEnumerable<string> CustomSources { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/HeaderConstants.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/HeaderConstants.cs
@@ -13,6 +13,7 @@ namespace NWebsec.Core.Common.HttpHeaders
         public static readonly string ContentSecurityPolicyHeader = "Content-Security-Policy";
         public static readonly string ContentSecurityPolicyReportOnlyHeader = "Content-Security-Policy-Report-Only";
         public static readonly string ReferrerPolicyHeader = "Referrer-Policy";
+        public static readonly string PermissionsPolicyHeader = "Permissions-Policy";
 
         public static readonly string[] CspSourceList =
         {

--- a/src/NWebsec.Core.Shared/HttpHeaders/IHeaderGenerator.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/IHeaderGenerator.cs
@@ -28,5 +28,8 @@ namespace NWebsec.Core.Common.HttpHeaders
 
         HeaderResult CreateCspResult(ICspConfiguration cspConfig, bool reportOnly,
             string builtinReportHandlerUri = null, ICspConfiguration oldCspConfig = null);
+
+        HeaderResult CreatePermissionsPolicyResult(
+            IPermissionsPolicyConfiguration permissionsPolicyPermissionConfiguration);
     }
 }

--- a/src/NWebsec.Core.Shared/HttpHeaders/IPermissionsPolicyConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/IPermissionsPolicyConfiguration.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+
+namespace NWebsec.Core.Common.HttpHeaders
+{
+    public interface IPermissionsPolicyConfiguration
+    {
+        bool Enabled { get; set; }
+        IPermissionsPolicyPermissionConfiguration AccelerometerPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration AmbientLightSensorPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration AutoplayPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration BatteryPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration CameraPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration CrossOriginIsolatedPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration DisplayCapturePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration DocumentDomainPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration EncryptedMediaPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration ExecutionWhileNotRenderedPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration ExecutionWhileOutOfViewportPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration FullscreenPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration GeolocationPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration GyroscopePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration HidPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration IdleDetectionPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration MagnetometerPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration MicrophonePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration MidiPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration NavigationOverridePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration PaymentPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration PictureInPicturePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration PublickeyCredentialsGetPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration ScreenWakeLockPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration SerialPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration SyncXhrPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration UsbPermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration WebSharePermission { get; set; }
+        IPermissionsPolicyPermissionConfiguration XrSpatialTrackingPermission { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/InvalidPermissionsPolicySourceException.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/InvalidPermissionsPolicySourceException.cs
@@ -1,0 +1,14 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+
+namespace NWebsec.Core.Common.HttpHeaders.PermissionsPolicy
+{
+    public class InvalidPermissionsPolicySourceException : Exception
+    {
+        public InvalidPermissionsPolicySourceException(string s) : base(s)
+        {
+
+        }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/PermissionsPolicySourceParseResult.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/PermissionsPolicySourceParseResult.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+namespace NWebsec.Core.Common.HttpHeaders.PermissionsPolicy
+{
+    internal class PermissionsPolicySourceParseResult
+    {
+        public string Scheme { get; set; }
+        public string Host { get; set; }
+        public string Port { get; set; }
+        public string PathAndQuery { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/PermissionsPolicyUriSource.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicy/PermissionsPolicyUriSource.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace NWebsec.Core.Common.HttpHeaders.PermissionsPolicy
+{
+    public class PermissionsPolicyUriSource
+    {
+        private const string HostRegex = @"^(\*\.)?([\p{Ll}\p{Lu}0-9\-]+)(\.[\p{Ll}\p{Lu}0-9\-]+)*$";
+        private static readonly string SchemeOnlyRegex = "^[a-zA-Z][a-zA-Z0-9+.-]*:$";
+        private static readonly string[] KnownSchemes = { "http", "https", "ws", "wss" };
+        private readonly string _source;
+
+        private PermissionsPolicyUriSource(string source)
+        {
+            _source = source;
+        }
+        
+        public override string ToString()
+        {
+            return _source;
+
+        }
+
+        public static string EncodeUri(Uri uri)
+        {
+
+            if (!uri.IsAbsoluteUri)
+            {
+                var uriString = uri.IsWellFormedOriginalString() ? uri.ToString() : Uri.EscapeUriString(uri.ToString());
+                return EscapeReservedPermissionsPolicyChars(uriString);
+            }
+
+            var host = uri.Host;
+            var encodedHost = EncodeHostname(host);
+
+            var needsReplacement = !host.Equals(encodedHost);
+
+            var authority = uri.GetComponents(UriComponents.SchemeAndServer, UriFormat.SafeUnescaped);
+
+            if (needsReplacement)
+            {
+                authority = authority.Replace(host, encodedHost);
+            }
+
+            if (uri.PathAndQuery.Equals("/"))
+            {
+                return authority;
+            }
+
+            return authority + EscapeReservedPermissionsPolicyChars(uri.PathAndQuery);
+        }
+
+        public static PermissionsPolicyUriSource Parse(string source)
+        {
+            if (String.IsNullOrEmpty(source)) throw new ArgumentException("Value was null or empty", "source");
+
+            if (source.Equals("*")) return new PermissionsPolicyUriSource(source);
+
+            Uri uriResult; //TODO figure out what happened to known schemes.
+            if (Uri.TryCreate(source, UriKind.Absolute, out uriResult) && KnownSchemes.Contains(uriResult.Scheme))
+            {
+                return new PermissionsPolicyUriSource(EncodeUri(uriResult));
+            }
+
+            //Scheme only source
+            if (Regex.IsMatch(source, SchemeOnlyRegex)) return new PermissionsPolicyUriSource(source.ToLower());
+
+            var parseResult = ParseSourceComponents(source);
+            var sb = new StringBuilder();
+
+            if (!String.IsNullOrEmpty(parseResult.Scheme))
+            {
+                if (!Regex.IsMatch(parseResult.Scheme, SchemeOnlyRegex))
+                {
+                    throw new InvalidPermissionsPolicySourceException("Invalid scheme in PermissionsPolicy source: " + source);
+                }
+                sb.Append(parseResult.Scheme.ToLower()).Append("//");
+            }
+
+            if (String.IsNullOrEmpty(parseResult.Host))
+            {
+                throw new InvalidPermissionsPolicySourceException("Could not parse host in PermissionsPolicy source: " + source);
+            }
+
+            if (!Regex.IsMatch(parseResult.Host, HostRegex))
+            {
+                throw new InvalidPermissionsPolicySourceException("Invalid host in PermissionsPolicy source: " + source);
+            }
+
+            sb.Append(EncodeHostname(parseResult.Host.ToLower()));
+
+            if (!String.IsNullOrEmpty(parseResult.Port))
+            {
+                if (!ValidatePort(parseResult.Port))
+                {
+                    throw new InvalidPermissionsPolicySourceException("Invalid port in PermissionsPolicy source: " + source);
+                }
+                sb.Append(":").Append(parseResult.Port);
+            }
+
+            if (!String.IsNullOrEmpty(parseResult.PathAndQuery))
+            {
+                sb.Append(EscapeReservedPermissionsPolicyChars(Uri.EscapeUriString(parseResult.PathAndQuery)));
+            }
+
+            return new PermissionsPolicyUriSource(sb.ToString());
+        }
+
+        private static PermissionsPolicySourceParseResult ParseSourceComponents(string uri)
+        {
+            const string regex = @"^((?<scheme>.*?:)\/\/)?" + // match anything up to ://
+                                 @"(?<host>.*?[^:\/])" + //then match anything up to a : or /
+                                 @"(:(?<port>(.*?[^\/])))?" + //then match port if exists up to a /
+                                 @"(?<pathAndQuery>\/.*)?$"; //grab the rest
+
+            var re = new Regex(regex, RegexOptions.ExplicitCapture);
+            var result = re.Match(uri);
+
+            if (!result.Success)
+            {
+                throw new InvalidPermissionsPolicySourceException("Malformed PermissionsPolicy source: " + uri);
+            }
+
+            return new PermissionsPolicySourceParseResult
+            {
+                Scheme = result.Groups["scheme"].Value,
+                Host = result.Groups["host"].Value,
+                Port = result.Groups["port"].Value,
+                PathAndQuery = result.Groups["pathAndQuery"].Value
+            };
+        }
+
+        private static string EncodeHostname(string hostname)
+        {
+            var idn = new IdnMapping();
+
+            return idn.GetAscii(hostname);
+        }
+
+        //TODO: Add parentheses and equals to escaped chars?
+        private static string EscapeReservedPermissionsPolicyChars(string pathAndQuery)
+        {
+            char[] encodeChars = { ';', ',' };
+
+            if (pathAndQuery.IndexOfAny(encodeChars) == -1)
+            {
+                return pathAndQuery;
+            }
+
+            var sb = new StringBuilder(pathAndQuery);
+            sb.Replace(";", "%3B");
+            sb.Replace(",", "%2C");
+
+            return sb.ToString();
+        }
+
+        private static bool ValidatePort(string port)
+        {
+            if (port.Equals("*")) return true;
+
+            var isInt = Int32.TryParse(port, out var portNumber);
+            return isInt && portNumber > 0 && portNumber <= 65535;
+        }
+    }
+}

--- a/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicyConfiguration.cs
+++ b/src/NWebsec.Core.Shared/HttpHeaders/PermissionsPolicyConfiguration.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+
+namespace NWebsec.Core.Common.HttpHeaders
+{
+    public class PermissionsPolicyConfiguration : IPermissionsPolicyConfiguration
+    {
+        public PermissionsPolicyConfiguration()
+        {
+            AccelerometerPermission = new PermissionsPolicyPermissionConfiguration();
+            AmbientLightSensorPermission = new PermissionsPolicyPermissionConfiguration();
+            AutoplayPermission = new PermissionsPolicyPermissionConfiguration();
+            BatteryPermission = new PermissionsPolicyPermissionConfiguration();
+            CameraPermission = new PermissionsPolicyPermissionConfiguration();
+            CrossOriginIsolatedPermission = new PermissionsPolicyPermissionConfiguration();
+            DisplayCapturePermission = new PermissionsPolicyPermissionConfiguration();
+            DocumentDomainPermission = new PermissionsPolicyPermissionConfiguration();
+            EncryptedMediaPermission = new PermissionsPolicyPermissionConfiguration();
+            ExecutionWhileNotRenderedPermission = new PermissionsPolicyPermissionConfiguration();
+            ExecutionWhileOutOfViewportPermission = new PermissionsPolicyPermissionConfiguration();
+            FullscreenPermission = new PermissionsPolicyPermissionConfiguration();
+            GeolocationPermission = new PermissionsPolicyPermissionConfiguration();
+            GyroscopePermission = new PermissionsPolicyPermissionConfiguration();
+            HidPermission = new PermissionsPolicyPermissionConfiguration();
+            IdleDetectionPermission = new PermissionsPolicyPermissionConfiguration();
+            MagnetometerPermission = new PermissionsPolicyPermissionConfiguration();
+            MicrophonePermission = new PermissionsPolicyPermissionConfiguration();
+            MidiPermission = new PermissionsPolicyPermissionConfiguration();
+            NavigationOverridePermission = new PermissionsPolicyPermissionConfiguration();
+            PaymentPermission = new PermissionsPolicyPermissionConfiguration();
+            PictureInPicturePermission = new PermissionsPolicyPermissionConfiguration();
+            PublickeyCredentialsGetPermission = new PermissionsPolicyPermissionConfiguration();
+            ScreenWakeLockPermission = new PermissionsPolicyPermissionConfiguration();
+            SerialPermission = new PermissionsPolicyPermissionConfiguration();
+            SyncXhrPermission = new PermissionsPolicyPermissionConfiguration();
+            UsbPermission = new PermissionsPolicyPermissionConfiguration();
+            WebSharePermission = new PermissionsPolicyPermissionConfiguration();
+            XrSpatialTrackingPermission = new PermissionsPolicyPermissionConfiguration();
+        }
+
+        public bool Enabled { get; set; }
+        public IPermissionsPolicyPermissionConfiguration AccelerometerPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration AmbientLightSensorPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration AutoplayPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration BatteryPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration CameraPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration CrossOriginIsolatedPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration DisplayCapturePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration DocumentDomainPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration EncryptedMediaPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration ExecutionWhileNotRenderedPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration ExecutionWhileOutOfViewportPermission{ get; set; }
+        public IPermissionsPolicyPermissionConfiguration FullscreenPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration GeolocationPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration GyroscopePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration HidPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration IdleDetectionPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration MagnetometerPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration MicrophonePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration MidiPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration NavigationOverridePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration PaymentPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration PictureInPicturePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration PublickeyCredentialsGetPermission {get; set;}
+        public IPermissionsPolicyPermissionConfiguration ScreenWakeLockPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration SerialPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration SyncXhrPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration UsbPermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration WebSharePermission { get; set; }
+        public IPermissionsPolicyPermissionConfiguration XrSpatialTrackingPermission { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/Middleware/Options/IFluentPermissionsPolicyOptions.cs
+++ b/src/NWebsec.Core.Shared/Middleware/Options/IFluentPermissionsPolicyOptions.cs
@@ -1,0 +1,214 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+using NWebsec.Core.Common.Fluent;
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+
+namespace NWebsec.Core.Common.Middleware.Options
+{
+    public interface IFluentPermissionsPolicyOptions : IFluentInterface
+    {
+        /// <summary>
+        /// Configures the accelerometer permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions AccelerometerSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the ambient-light-sensor permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions AmbientLightSensorSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the autoplay permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions AutoplaySources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the battery permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions BatterySources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the camera permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions CameraSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the cross-origin-isolated permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions CrossOriginIsolatedSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the display-capture permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions DisplayCaptureSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the document-domain permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions DocumentDomainSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the encrypted-media permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions EncryptedMediaSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the execution-while-not-rendered permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions ExecutionWhileNotRenderedSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the execution-while-out-of-viewport permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions ExecutionWhileOutOfViewportSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the fullscreen permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions FullscreenSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the geolocation permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions GeolocationSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the gyroscope permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions GyroscopeSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the hid permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions HidSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the idle-detection permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions IdleDetectionSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the magnetometer permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions MagnetometerSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the microphone permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions MicrophoneSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the midi permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions MidiSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the navigation-override permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions NavigationOverrideSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the payment permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions PaymentSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the picture-in-picture permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions PictureInPictureSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the publickey-credentials-get permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions PublickeyCredentialsGetSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the screen-wake-lock permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions ScreenWakeLockSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the serial permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions SerialSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the sync-xhr permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions SyncXhrSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the usb permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions UsbSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the web-share permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions WebShareSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+
+        /// <summary>
+        /// Configures the xr-spatial-tracking permission.
+        /// </summary>
+        /// <param name="configurer">An <see cref="Action"/> that configures the sources for the permission.</param>
+        /// <returns>The current <see cref="PermissionsPolicyOptions" /> instance.</returns>
+        IFluentPermissionsPolicyOptions XrSpatialTrackingSources(Action<IPermissionsPolicyPermissionConfiguration> configurer);
+    }
+}

--- a/src/NWebsec.Core.Shared/Middleware/Options/PermissionsPolicyOptions.cs
+++ b/src/NWebsec.Core.Shared/Middleware/Options/PermissionsPolicyOptions.cs
@@ -1,0 +1,215 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+using NWebsec.Core.Common.HttpHeaders;
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+
+namespace NWebsec.Core.Common.Middleware.Options
+{
+    public class PermissionsPolicyOptions : IPermissionsPolicyConfiguration, IFluentPermissionsPolicyOptions
+    {
+        public bool Enabled { get; set; } = true;
+        public IPermissionsPolicyPermissionConfiguration AccelerometerPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration AmbientLightSensorPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration AutoplayPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration BatteryPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration CameraPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration CrossOriginIsolatedPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration DisplayCapturePermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration DocumentDomainPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration EncryptedMediaPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration ExecutionWhileNotRenderedPermission{ get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration ExecutionWhileOutOfViewportPermission{ get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration FullscreenPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration GeolocationPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration GyroscopePermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration HidPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration IdleDetectionPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration MagnetometerPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration MicrophonePermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration MidiPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration NavigationOverridePermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration PaymentPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration PictureInPicturePermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration PublickeyCredentialsGetPermission {get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration ScreenWakeLockPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration SerialPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration SyncXhrPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration UsbPermission { get; set; } = new PermissionsPolicyPermission();
+        public IPermissionsPolicyPermissionConfiguration WebSharePermission { get; set; } = new PermissionsPolicyPermission(); 
+        public IPermissionsPolicyPermissionConfiguration XrSpatialTrackingPermission { get; set; } = new PermissionsPolicyPermission();
+        public IFluentPermissionsPolicyOptions AccelerometerSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(AccelerometerPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions AmbientLightSensorSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(AmbientLightSensorPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions AutoplaySources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(AutoplayPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions BatterySources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(BatteryPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions CameraSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(CameraPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions CrossOriginIsolatedSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(CrossOriginIsolatedPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions DisplayCaptureSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(DisplayCapturePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions DocumentDomainSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(DocumentDomainPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions EncryptedMediaSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(EncryptedMediaPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions ExecutionWhileNotRenderedSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(ExecutionWhileNotRenderedPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions ExecutionWhileOutOfViewportSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(ExecutionWhileOutOfViewportPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions FullscreenSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(FullscreenPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions GeolocationSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(GeolocationPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions GyroscopeSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(GyroscopePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions HidSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(HidPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions IdleDetectionSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(IdleDetectionPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions MagnetometerSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(MagnetometerPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions MicrophoneSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(MicrophonePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions MidiSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(MidiPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions NavigationOverrideSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(NavigationOverridePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions PaymentSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(PaymentPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions PictureInPictureSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(PictureInPicturePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions PublickeyCredentialsGetSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(PublickeyCredentialsGetPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions ScreenWakeLockSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(ScreenWakeLockPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions SerialSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(SerialPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions SyncXhrSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(SyncXhrPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions UsbSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(UsbPermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions WebShareSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(WebSharePermission);
+            return this;
+        }
+
+        public IFluentPermissionsPolicyOptions XrSpatialTrackingSources(Action<IPermissionsPolicyPermissionConfiguration> configurer)
+        {
+            configurer(XrSpatialTrackingPermission);
+            return this;
+        }
+    }
+}

--- a/src/NWebsec.Core.Shared/Middleware/Options/PermissionsPolicyPermission.cs
+++ b/src/NWebsec.Core.Shared/Middleware/Options/PermissionsPolicyPermission.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+
+namespace NWebsec.Core.Common.Middleware.Options
+{
+    public class PermissionsPolicyPermission : IPermissionsPolicyPermissionConfiguration
+    {
+        public PermissionsPolicyPermission()
+        {
+            Enabled = true;
+        }
+
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool Enabled { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool AllSrc { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool NoneSrc { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public bool SelfSrc { get; set; }
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public IEnumerable<string> CustomSources { get; set; }
+    }
+}

--- a/src/NWebsec.Core.Shared/NWebsec.Core.Shared.projitems
+++ b/src/NWebsec.Core.Shared/NWebsec.Core.Shared.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\ICspSandboxDirectiveConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\ICspUpgradeDirectiveConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IHstsConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IPermissionsPolicyPermissionConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IRedirectValidationConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IReferrerPolicyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\ISameHostHttpsRedirectConfiguration.cs" />
@@ -39,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IXFrameOptionsConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IXRobotsTagConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\IXXssProtectionConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\PermissionsPolicyPermissionPermissionConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\RedirectValidationConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\ReferrerPolicyConfiguration.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\Configuration\SameHostHttpsRedirectConfiguration.cs" />
@@ -57,6 +59,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\HeaderGenerator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\HeaderResult.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\IHeaderGenerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\IPermissionsPolicyConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\PermissionsPolicyConfiguration.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\PermissionsPolicy\InvalidPermissionsPolicySourceException.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\PermissionsPolicy\PermissionsPolicySourceParseResult.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\PermissionsPolicy\PermissionsPolicyUriSource.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\ReferrerPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\XfoPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)HttpHeaders\XXssPolicy.cs" />
@@ -73,11 +80,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentCspReportUriDirective.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentCspSandboxDirective.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentHstsOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentPermissionsPolicyOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentRedirectValidationOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentReferrerPolicyOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentXFrameOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentXRobotsTagOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\IFluentXXssProtectionOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\PermissionsPolicyOptions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\PermissionsPolicyPermission.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\RedirectValidationOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\ReferrerPolicyOptions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Middleware\Options\XFrameOptions.cs" />

--- a/src/NWebsec.Core.Shared/NWebsecContext.cs
+++ b/src/NWebsec.Core.Shared/NWebsecContext.cs
@@ -1,5 +1,6 @@
 ﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
 
+using NWebsec.Core.Common.HttpHeaders;
 using NWebsec.Core.Common.HttpHeaders.Configuration;
 
 namespace NWebsec.Core.Common
@@ -17,6 +18,7 @@ namespace NWebsec.Core.Common
         public IXXssProtectionConfiguration XXssProtection { get; set; }
         public IReferrerPolicyConfiguration ReferrerPolicy { get; set; } //TODO tests??
         public ICspConfiguration Csp { get; set; }
+        public IPermissionsPolicyConfiguration PermissionsPolicy { get; set; }
         public ICspConfiguration CspReportOnly { get; set; }
 
         public ConfigurationOverrides ConfigOverrides { get; set; }

--- a/test/NWebsec.AspNetCore.Middleware.Tests/Middleware/PermissionsPolicyMiddlewareTests.cs
+++ b/test/NWebsec.AspNetCore.Middleware.Tests/Middleware/PermissionsPolicyMiddlewareTests.cs
@@ -1,0 +1,80 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Middleware.Tests.Middleware
+{
+    public class PermissionsPolicyMiddlewareTests
+    {
+        [Fact]
+        public async Task PermissionsPolicyMiddlewareNotUsed_HeaderNotPresent()
+        {
+            using (var server = new TestServer(new WebHostBuilder().Configure(app =>
+                   {
+                       app.Run(async context =>
+                       {
+                           context.Response.ContentType = "text/plain";
+                           await context.Response.WriteAsync("Hello world");
+                       });
+                   })))
+            {
+                using (var httpClient = server.CreateClient())
+                {
+                    var response = await httpClient.GetAsync("https://localhost/");
+                    Assert.False(response.Headers.Contains("Permissions-Policy"));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PermissionsPolicyMiddlewareUsed_HeaderPresent()
+        {
+            using (var server = new TestServer(new WebHostBuilder().Configure(app =>
+                   {
+                       app.UsePermissionsPolicy(config => config.AccelerometerSources(s => s.None()));
+                       app.Run(async context =>
+                       {
+                           context.Response.ContentType = "text/plain";
+                           await context.Response.WriteAsync("Hello world");
+                       });
+                   })))
+            {
+                using (var httpClient = server.CreateClient())
+                {
+                    var response = await httpClient.GetAsync("https://localhost/");
+                    Assert.True(response.Headers.Contains("Permissions-Policy"));
+                }
+            }
+        }
+
+        [Fact]
+        public async Task PermissionsPolicyMiddlewareUsed_ComplexHeaderPresent()
+        {
+            using (var server = new TestServer(new WebHostBuilder().Configure(app =>
+                   {
+                       app.UsePermissionsPolicy(config => config
+                           .GeolocationSources(s => s.Self().CustomSources("https://example.com"))
+                           .MicrophoneSources(s => s.None()));
+                       app.Run(async context =>
+                       {
+                           context.Response.ContentType = "text/plain";
+                           await context.Response.WriteAsync("Hello world");
+                       });
+                   })))
+            {
+                using (var httpClient = server.CreateClient())
+                {
+                    var response = await httpClient.GetAsync("https://localhost/");
+                    Assert.True(response.Headers.Contains("Permissions-Policy"));
+                    Assert.Equal("geolocation=(self \"https://example.com\"), microphone=()", response.Headers.GetValues("Permissions-Policy").Single());
+                }
+            }
+        }
+    }
+}

--- a/test/NWebsec.AspNetCore.Middleware.Tests/PermissionsPolicyPermissionExtensionsTests.cs
+++ b/test/NWebsec.AspNetCore.Middleware.Tests/PermissionsPolicyPermissionExtensionsTests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) André N. Klingsheim. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using NWebsec.Core.Common.Middleware.Options;
+using Xunit;
+
+namespace NWebsec.AspNetCore.Middleware.Tests
+{
+    public class PermissionsPolicyPermissionExtensionsTests
+    {
+        [Fact]
+        public void None_DirectiveSourcesConfigured_ThrowsException()
+        {
+            var directiveSelf = new PermissionsPolicyPermission();
+            var directiveAll = new PermissionsPolicyPermission();
+            var directiveSources = new PermissionsPolicyPermission();
+
+            directiveSelf.Self();
+            directiveAll.All();
+            directiveSources.CustomSources("https:");
+
+            Assert.Throws<InvalidOperationException>(() => directiveSelf.None());
+            Assert.Throws<InvalidOperationException>(() => directiveAll.None());
+            Assert.Throws<InvalidOperationException>(() => directiveSources.None());
+        }
+
+        [Fact]
+        public void None_SetsNoneSrc()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            directive.None();
+
+            Assert.True(directive.NoneSrc);
+        }
+
+        [Fact]
+        public void All_SetsAllSrc()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            directive.All();
+
+            Assert.True(directive.AllSrc);
+        }
+
+        [Fact]
+        public void Self_SetsSelfSrc()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            directive.Self();
+
+            Assert.True(directive.SelfSrc);
+        }
+
+        [Fact]
+        public void CustomSources_ValidSource_SetCustomSources()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            directive.CustomSources("source1", "source2");
+
+            var expectedResult = new[] { "source1", "source2" };
+            Assert.True(expectedResult.SequenceEqual(directive.CustomSources));
+        }
+
+        [Fact]
+        public void CustomSources_NoParams_ThrowException()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            Assert.Throws<ArgumentException>(() => directive.CustomSources());
+        }
+
+        [Fact]
+        public void CustomSources_InvalidSource_ThrowsException()
+        {
+            var directive = new PermissionsPolicyPermission();
+
+            Assert.Throws<ArgumentException>(() => directive.CustomSources("https:", "nwebsec.*.com"));
+        }
+    }
+}

--- a/test/NWebsec.Core.SharedProject.Tests/HttpHeaders/HeaderGeneratorPermissionsPolicyTests.cs
+++ b/test/NWebsec.Core.SharedProject.Tests/HttpHeaders/HeaderGeneratorPermissionsPolicyTests.cs
@@ -1,0 +1,545 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NWebsec.Core.Common.HttpHeaders;
+using NWebsec.Core.Common.HttpHeaders.Configuration;
+using Xunit;
+
+namespace NWebsec.Core.SharedProject.Tests.HttpHeaders
+{
+    public class HeaderGeneratorPermissionsPolicyTests
+    {
+        private readonly HeaderGenerator _generator;
+        private const string PpHeaderName = "Permissions-Policy";
+
+        public HeaderGeneratorPermissionsPolicyTests()
+        {
+            _generator = new HeaderGenerator();
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_Disabled_ReturnsEmptyResults()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration{Enabled = false};
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledButNoPermissionsEnabled_ReturnsEmptyResults()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration { Enabled = true };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithAccelerometer_ReturnsPermissionsPolicyWithAccelerometer()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                AccelerometerPermission = { SelfSrc = true}
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("accelerometer=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithAmbientLightSensor_ReturnsPermissionsPolicyWithAmbientLightSensor()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                AmbientLightSensorPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("ambient-light-sensor=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithAutoplay_ReturnsPermissionsPolicyWithAutoplay()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                AutoplayPermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("autoplay=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithBattery_ReturnsPermissionsPolicyWithBattery()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                BatteryPermission = { CustomSources = new List<string>{"https://example.com"} }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("battery=(\"https://example.com\")", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithCamera_ReturnsPermissionsPolicyWithCamera()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                CameraPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("camera=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithCrossOriginIsolated_ReturnsPermissionsPolicyWithCrossOriginIsolated()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                CrossOriginIsolatedPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("cross-origin-isolated=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithDisplayCapture_ReturnsPermissionsPolicyWithDisplayCapture()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                DisplayCapturePermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("display-capture=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithDocumentDomain_ReturnsPermissionsPolicyWithDocumentDomain()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                DocumentDomainPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("document-domain=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithEncryptedMedia_ReturnsPermissionsPolicyWithEncryptedMedia()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                EncryptedMediaPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("encrypted-media=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithExecutionWhileNotRendered_ReturnsPermissionsPolicyWithExecutionWhileNotRendered()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                ExecutionWhileNotRenderedPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("execution-while-not-rendered=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithExecutionWhileOutOfViewport_ReturnsPermissionsPolicyWithExecutionWhileOutOfViewport()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                ExecutionWhileOutOfViewportPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("execution-while-out-of-viewport=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithFullscreen_ReturnsPermissionsPolicyWithFullscreen()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                FullscreenPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("fullscreen=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithGeolocation_ReturnsPermissionsPolicyWithGeolocation()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                GeolocationPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("geolocation=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithGyroscope_ReturnsPermissionsPolicyWithGyroscope()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                GyroscopePermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("gyroscope=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithHid_ReturnsPermissionsPolicyWithHid()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                HidPermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("hid=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithIdleDetection_ReturnsPermissionsPolicyWithIdleDetection()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                IdleDetectionPermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("idle-detection=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithMagnetometer_ReturnsPermissionsPolicyWithMagnetometer()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                MagnetometerPermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("magnetometer=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithMicrophone_ReturnsPermissionsPolicyWithMicrophone()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                MicrophonePermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("microphone=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithMidi_ReturnsPermissionsPolicyWithMidi()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                MidiPermission = { AllSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("midi=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithNavigationOverride_ReturnsPermissionsPolicyWithNavigationOverride()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                NavigationOverridePermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("navigation-override=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithPayment_ReturnsPermissionsPolicyWithPayment()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                PaymentPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("payment=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithPictureInPicture_ReturnsPermissionsPolicyWithPictureInPicture()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                PictureInPicturePermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("picture-in-picture=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithPublickeyCredentialsGet_ReturnsPermissionsPolicyWithPublickeyCredentialsGet()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                PublickeyCredentialsGetPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("publickey-credentials-get=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithScreenWakeLock_ReturnsPermissionsPolicyWithScreenWakeLock()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                ScreenWakeLockPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("screen-wake-lock=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithSerial_ReturnsPermissionsPolicyWithSerial()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                SerialPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("serial=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithSyncXhr_ReturnsPermissionsPolicyWithSyncXhr()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                SyncXhrPermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("sync-xhr=()", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithUsb_ReturnsPermissionsPolicyWithUsb()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                UsbPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("usb=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithWebShare_ReturnsPermissionsPolicyWithWebShare()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                WebSharePermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("web-share=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithXrSpatialTracking_ReturnsPermissionsPolicyWithXrSpatialTracking()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                XrSpatialTrackingPermission = { SelfSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("xr-spatial-tracking=(self)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithMultiplePermissionsAndSources()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                FullscreenPermission =
+                {
+                    SelfSrc = true, 
+                    CustomSources = new List<string>{"https://example.com", "https://another.example.com"}
+                },
+                GeolocationPermission = {AllSrc = true},
+                CameraPermission = {NoneSrc = true}
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("camera=(), fullscreen=(self \"https://example.com\" \"https://another.example.com\"), geolocation=(*)", result.Value);
+        }
+
+        [Fact]
+        public void CreatePermissionsPolicyResult_EnabledWithMultiplePermissions()
+        {
+            var permissionsPolicyConfiguration = new PermissionsPolicyConfiguration
+            {
+                Enabled = true,
+                GeolocationPermission =
+                {
+                    SelfSrc = true,
+                    CustomSources = new List<string>{"https://example.com"}
+                },
+                MicrophonePermission = { NoneSrc = true }
+            };
+            var result = _generator.CreatePermissionsPolicyResult(permissionsPolicyConfiguration);
+
+            Assert.NotNull(result);
+            Assert.Equal(HeaderResult.ResponseAction.Set, result.Action);
+            Assert.Equal(PpHeaderName, result.Name);
+            Assert.Equal("geolocation=(self \"https://example.com\"), microphone=()", result.Value);
+        }
+    }
+}


### PR DESCRIPTION
Based on the CSP implementation, I have added a similar implementation for the permissions policy.
Some duplication because it is very similar to CSP, but I did not want to refer to any CSP-specific code in the Permissions policy.

Only added for ASP.NET Core version.

Solves https://github.com/NWebsec/NWebsec/issues/185 & https://github.com/NWebsec/NWebsec/issues/134

Looking forward to seeing some feedback :) 